### PR TITLE
Add "due soon" functionality

### DIFF
--- a/TodoTxtMac/TTMAppController.m
+++ b/TodoTxtMac/TTMAppController.m
@@ -89,6 +89,7 @@ static NSDictionary *defaultValues() {
                 @NO, @"useCustomColorForThresholdDates",
                 @NO, @"useCustomColorForCreationDates",
                 [NSArchiver archivedDataWithRootObject:[NSColor redColor]], @"dueTodayColor",
+                [NSArchiver archivedDataWithRootObject:[NSColor orangeColor]], @"dueSoonColor",
                 [NSArchiver archivedDataWithRootObject:[NSColor purpleColor]], @"overdueColor",
                 [NSArchiver archivedDataWithRootObject:[NSColor darkGrayColor]], @"projectColor",
                 [NSArchiver archivedDataWithRootObject:[NSColor darkGrayColor]], @"contextColor",
@@ -106,6 +107,7 @@ static NSDictionary *defaultValues() {
                 @NO, @"hideFutureTasks",
                 @NO, @"closingLastWindowClosesApplication",
                 @NO, @"hideHiddenTasks",
+                @2, @"dueSoonDays",
                 nil];
     }
     return dict;

--- a/TodoTxtMac/TTMPredicateEditorDueRowTemplate.m
+++ b/TodoTxtMac/TTMPredicateEditorDueRowTemplate.m
@@ -52,33 +52,33 @@
 #pragma mark - Class Property Getters
 
 - (NSPopUpButton*)keypathPopUp {
-	if(!_keypathPopUp) {
-		NSMenu *keypathMenu = [[NSMenu alloc]
+    if(!_keypathPopUp) {
+        NSMenu *keypathMenu = [[NSMenu alloc]
                                initWithTitle:@"due state menu"];
         
-		NSMenuItem *menuItem = [[NSMenuItem alloc]
+        NSMenuItem *menuItem = [[NSMenuItem alloc]
                                 initWithTitle:@"due state"
                                 action:nil
                                 keyEquivalent:@""];
-		[menuItem setRepresentedObject:[NSExpression expressionForKeyPath:@"dueState"]];
-		[menuItem setEnabled:YES];
+        [menuItem setRepresentedObject:[NSExpression expressionForKeyPath:@"dueState"]];
+        [menuItem setEnabled:YES];
         
-		[keypathMenu addItem:menuItem];
+        [keypathMenu addItem:menuItem];
         
-		_keypathPopUp = [[NSPopUpButton alloc] initWithFrame:NSZeroRect pullsDown:NO];
-		[_keypathPopUp setMenu:keypathMenu];
-	}
-	return _keypathPopUp;
+        _keypathPopUp = [[NSPopUpButton alloc] initWithFrame:NSZeroRect pullsDown:NO];
+        [_keypathPopUp setMenu:keypathMenu];
+    }
+    return _keypathPopUp;
 }
 
 - (NSPopUpButton*)dueStatePopUp {
-	if (!_dueStatePopUp) {
-		NSMenuItem *dueTodayItem = [[NSMenuItem alloc] initWithTitle:@"due today"
+    if (!_dueStatePopUp) {
+        NSMenuItem *dueTodayItem = [[NSMenuItem alloc] initWithTitle:@"due today"
                                                               action:nil
                                                        keyEquivalent:@""];
-		[dueTodayItem setRepresentedObject:[NSExpression expressionForConstantValue:@(DueToday)]];
-		[dueTodayItem setEnabled:YES];
-		[dueTodayItem setTag:(long)DueToday];
+        [dueTodayItem setRepresentedObject:[NSExpression expressionForConstantValue:@(DueToday)]];
+        [dueTodayItem setEnabled:YES];
+        [dueTodayItem setTag:(long)DueToday];
         
         NSMenuItem *dueSoonItem = [[NSMenuItem alloc] initWithTitle:@"due soon"
                                                               action:nil
@@ -86,20 +86,20 @@
         [dueSoonItem setRepresentedObject:[NSExpression expressionForConstantValue:@(DueSoon)]];
         [dueSoonItem setEnabled:YES];
         [dueSoonItem setTag:(long)DueSoon];
-
-		NSMenuItem *overdueItem = [[NSMenuItem alloc] initWithTitle:@"overdue"
-                                                              action:nil
-                                                       keyEquivalent:@""];
-		[overdueItem setRepresentedObject:[NSExpression expressionForConstantValue:@(Overdue)]];
-		[overdueItem setEnabled:YES];
-		[overdueItem setTag:(long)Overdue];
         
-		NSMenuItem *notDueItem = [[NSMenuItem alloc] initWithTitle:@"not due"
+        NSMenuItem *overdueItem = [[NSMenuItem alloc] initWithTitle:@"overdue"
                                                               action:nil
                                                        keyEquivalent:@""];
-		[notDueItem setRepresentedObject:[NSExpression expressionForConstantValue:@(NotDue)]];
-		[notDueItem setEnabled:YES];
-		[notDueItem setTag:(long)NotDue];
+        [overdueItem setRepresentedObject:[NSExpression expressionForConstantValue:@(Overdue)]];
+        [overdueItem setEnabled:YES];
+        [overdueItem setTag:(long)Overdue];
+        
+        NSMenuItem *notDueItem = [[NSMenuItem alloc] initWithTitle:@"not due"
+                                                              action:nil
+                                                       keyEquivalent:@""];
+        [notDueItem setRepresentedObject:[NSExpression expressionForConstantValue:@(NotDue)]];
+        [notDueItem setEnabled:YES];
+        [notDueItem setTag:(long)NotDue];
 
         NSMenuItem *noDueDateItem = [[NSMenuItem alloc] initWithTitle:@"no due date"
                                                             action:nil
@@ -109,16 +109,16 @@
         [noDueDateItem setTag:(long)NoDueDate];
         
         NSMenu *dueStateMenu = [[NSMenu alloc] initWithTitle:@"Due State"];
-		[dueStateMenu addItem:dueTodayItem];
+        [dueStateMenu addItem:dueTodayItem];
         [dueStateMenu addItem:dueSoonItem];
-		[dueStateMenu addItem:overdueItem];
+        [dueStateMenu addItem:overdueItem];
         [dueStateMenu addItem:notDueItem];
         [dueStateMenu addItem:noDueDateItem];
         
-		_dueStatePopUp = [[NSPopUpButton alloc] initWithFrame:NSZeroRect pullsDown:NO];
-		[_dueStatePopUp setMenu:dueStateMenu];
-	}
-	return _dueStatePopUp;
+        _dueStatePopUp = [[NSPopUpButton alloc] initWithFrame:NSZeroRect pullsDown:NO];
+        [_dueStatePopUp setMenu:dueStateMenu];
+    }
+    return _dueStatePopUp;
 }
 
 #pragma mark - NSPredicateEditorRowTemplate Method Overrides
@@ -140,14 +140,14 @@
 - (NSPredicate*)predicateWithSubpredicates:(NSArray*)subpredicates {
     NSPredicate *p = [super predicateWithSubpredicates:subpredicates];
     NSComparisonPredicate *comparison = (NSComparisonPredicate*)p;
-	NSPredicate *newPredicate =
+    NSPredicate *newPredicate =
         [NSComparisonPredicate
          predicateWithLeftExpression:[[self.keypathPopUp selectedItem] representedObject]
          rightExpression:[[self.dueStatePopUp selectedItem] representedObject]
          modifier:[comparison comparisonPredicateModifier]
          type:[comparison predicateOperatorType]
          options:[comparison options]];
-	return newPredicate;
+    return newPredicate;
 }
 
 @end

--- a/TodoTxtMac/TTMPredicateEditorDueRowTemplate.m
+++ b/TodoTxtMac/TTMPredicateEditorDueRowTemplate.m
@@ -79,6 +79,13 @@
 		[dueTodayItem setRepresentedObject:[NSExpression expressionForConstantValue:@(DueToday)]];
 		[dueTodayItem setEnabled:YES];
 		[dueTodayItem setTag:(long)DueToday];
+        
+        NSMenuItem *dueSoonItem = [[NSMenuItem alloc] initWithTitle:@"due soon"
+                                                              action:nil
+                                                       keyEquivalent:@""];
+        [dueSoonItem setRepresentedObject:[NSExpression expressionForConstantValue:@(DueSoon)]];
+        [dueSoonItem setEnabled:YES];
+        [dueSoonItem setTag:(long)DueSoon];
 
 		NSMenuItem *overdueItem = [[NSMenuItem alloc] initWithTitle:@"overdue"
                                                               action:nil
@@ -103,6 +110,7 @@
         
         NSMenu *dueStateMenu = [[NSMenu alloc] initWithTitle:@"Due State"];
 		[dueStateMenu addItem:dueTodayItem];
+        [dueStateMenu addItem:dueSoonItem];
 		[dueStateMenu addItem:overdueItem];
         [dueStateMenu addItem:notDueItem];
         [dueStateMenu addItem:noDueDateItem];

--- a/TodoTxtMac/TTMPreferences.xib
+++ b/TodoTxtMac/TTMPreferences.xib
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
         <capability name="box content view" minToolsVersion="7.0"/>
         <capability name="stacking Non-gravity area distributions on NSStackView" minToolsVersion="7.0" minSystemVersion="10.11"/>
     </dependencies>
@@ -468,20 +468,95 @@
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="110" id="U8d-uz-qYo"/>
                                                     </constraints>
-                                                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                                                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                 </box>
-                                                <box autoresizesSubviews="NO" title="Updates" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="0l4-KA-rkx" userLabel="Updates Box">
+                                                <box autoresizesSubviews="NO" borderType="line" title="Due Soon" translatesAutoresizingMaskIntoConstraints="NO" id="W0D-QI-Eyo" userLabel="Due Soon Box">
+                                                    <rect key="frame" x="7" y="96" width="570" height="69"/>
+                                                    <view key="contentView" id="Wss-Q9-1pF">
+                                                        <rect key="frame" x="1" y="1" width="568" height="53"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                        <subviews>
+                                                            <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gQb-j1-LT2">
+                                                                <rect key="frame" x="10" y="21" width="548" height="22"/>
+                                                                <subviews>
+                                                                    <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BKX-em-mSh">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="438" height="22"/>
+                                                                        <subviews>
+                                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="h5l-nN-6Bt">
+                                                                                <rect key="frame" x="-2" y="3" width="236" height="17"/>
+                                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Due Soon means tasks due in the next" id="pbt-MI-15W">
+                                                                                    <font key="font" metaFont="system"/>
+                                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                </textFieldCell>
+                                                                            </textField>
+                                                                            <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="usZ-UQ-wwE">
+                                                                                <rect key="frame" x="240" y="0.0" width="55" height="22"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="width" constant="55" id="yUB-sY-eRU"/>
+                                                                                </constraints>
+                                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="x4z-LX-XPN">
+                                                                                    <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="lue-OY-Bc9"/>
+                                                                                    <font key="font" metaFont="system"/>
+                                                                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                </textFieldCell>
+                                                                                <connections>
+                                                                                    <binding destination="p0U-mu-Cyy" name="value" keyPath="values.dueSoonDays" id="ZsF-sZ-MrH"/>
+                                                                                </connections>
+                                                                            </textField>
+                                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QK5-3a-rVB">
+                                                                                <rect key="frame" x="301" y="5" width="139" height="17"/>
+                                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="days (set 0 to disable)" id="eJj-LN-p5c">
+                                                                                    <font key="font" metaFont="system"/>
+                                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                </textFieldCell>
+                                                                            </textField>
+                                                                        </subviews>
+                                                                        <constraints>
+                                                                            <constraint firstItem="usZ-UQ-wwE" firstAttribute="baseline" secondItem="h5l-nN-6Bt" secondAttribute="baseline" id="7A1-3u-1YQ"/>
+                                                                        </constraints>
+                                                                        <visibilityPriorities>
+                                                                            <integer value="1000"/>
+                                                                            <integer value="1000"/>
+                                                                            <integer value="1000"/>
+                                                                        </visibilityPriorities>
+                                                                        <customSpacing>
+                                                                            <real value="3.4028234663852886e+38"/>
+                                                                            <real value="3.4028234663852886e+38"/>
+                                                                            <real value="3.4028234663852886e+38"/>
+                                                                        </customSpacing>
+                                                                    </stackView>
+                                                                </subviews>
+                                                                <visibilityPriorities>
+                                                                    <integer value="1000"/>
+                                                                </visibilityPriorities>
+                                                                <customSpacing>
+                                                                    <real value="3.4028234663852886e+38"/>
+                                                                </customSpacing>
+                                                            </stackView>
+                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstItem="gQb-j1-LT2" firstAttribute="top" secondItem="Wss-Q9-1pF" secondAttribute="top" constant="10" id="Ije-qd-dil"/>
+                                                            <constraint firstAttribute="trailing" secondItem="gQb-j1-LT2" secondAttribute="trailing" constant="10" id="Qay-6r-n2c"/>
+                                                            <constraint firstItem="gQb-j1-LT2" firstAttribute="leading" secondItem="Wss-Q9-1pF" secondAttribute="leading" constant="10" id="drr-N6-QD1"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="65" id="9PF-uG-DwO" userLabel="height = 60"/>
+                                                    </constraints>
+                                                </box>
+                                                <box autoresizesSubviews="NO" borderType="line" title="Updates" translatesAutoresizingMaskIntoConstraints="NO" id="0l4-KA-rkx" userLabel="Updates Box">
                                                     <rect key="frame" x="7" y="-4" width="570" height="94"/>
                                                     <view key="contentView" id="nS2-eK-lnO">
                                                         <rect key="frame" x="1" y="1" width="568" height="78"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="i86-pj-NM3">
-                                                                <rect key="frame" x="10" y="23" width="548" height="45"/>
+                                                                <rect key="frame" x="10" y="25" width="548" height="43"/>
                                                                 <subviews>
                                                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="7BY-xZ-OO3">
-                                                                        <rect key="frame" x="-2" y="29" width="310" height="18"/>
+                                                                        <rect key="frame" x="-2" y="27" width="310" height="18"/>
                                                                         <buttonCell key="cell" type="check" title="Automatically check for updates to TodoTxtMac" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="edr-78-Twz">
                                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                             <font key="font" metaFont="system"/>
@@ -553,24 +628,28 @@
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="90" id="9Bn-Cq-egK"/>
                                                     </constraints>
-                                                    <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                                                    <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                 </box>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="yed-2J-abW" firstAttribute="leading" secondItem="uWq-47-nKi" secondAttribute="leading" constant="10" id="0T8-ox-uO3"/>
+                                                <constraint firstItem="0l4-KA-rkx" firstAttribute="top" secondItem="W0D-QI-Eyo" secondAttribute="bottom" constant="10" id="Cch-xi-luF"/>
                                                 <constraint firstItem="0l4-KA-rkx" firstAttribute="leading" secondItem="uWq-47-nKi" secondAttribute="leading" constant="10" id="J6A-u7-1Ns"/>
+                                                <constraint firstItem="W0D-QI-Eyo" firstAttribute="top" secondItem="eZp-tq-4Jf" secondAttribute="bottom" constant="10" id="MMQ-WP-wg5"/>
                                                 <constraint firstAttribute="trailing" secondItem="0l4-KA-rkx" secondAttribute="trailing" constant="10" id="THP-mQ-X2j"/>
                                                 <constraint firstAttribute="trailing" secondItem="yed-2J-abW" secondAttribute="trailing" constant="10" id="dIk-wL-uae"/>
                                                 <constraint firstAttribute="trailing" secondItem="eZp-tq-4Jf" secondAttribute="trailing" constant="10" id="dyy-vM-h1E"/>
                                                 <constraint firstItem="eZp-tq-4Jf" firstAttribute="leading" secondItem="uWq-47-nKi" secondAttribute="leading" constant="10" id="jgW-SY-Opr"/>
+                                                <constraint firstItem="W0D-QI-Eyo" firstAttribute="leading" secondItem="uWq-47-nKi" secondAttribute="leading" constant="10" id="nU9-5i-FRj"/>
+                                                <constraint firstAttribute="trailing" secondItem="W0D-QI-Eyo" secondAttribute="trailing" constant="10" id="pd1-ZY-Cgf"/>
                                             </constraints>
                                             <visibilityPriorities>
                                                 <integer value="1000"/>
                                                 <integer value="1000"/>
                                                 <integer value="1000"/>
+                                                <integer value="1000"/>
                                             </visibilityPriorities>
                                             <customSpacing>
+                                                <real value="3.4028234663852886e+38"/>
                                                 <real value="3.4028234663852886e+38"/>
                                                 <real value="3.4028234663852886e+38"/>
                                                 <real value="3.4028234663852886e+38"/>

--- a/TodoTxtMac/TTMTableViewDelegate.m
+++ b/TodoTxtMac/TTMTableViewDelegate.m
@@ -73,6 +73,10 @@
                                    boolForKey:@"useCustomColorForDueTodayTasks"]) ?
             [[NSUserDefaults standardUserDefaults] colorForKey:@"dueTodayColor"] :
             [NSColor redColor];
+        NSColor *dueSoonColor = ([[NSUserDefaults standardUserDefaults]
+                                   boolForKey:@"useCustomColorForDueSoonTasks"]) ?
+            [[NSUserDefaults standardUserDefaults] colorForKey:@"dueSoonColor"] :
+            [NSColor orangeColor];
         NSColor *overdueColor = ([[NSUserDefaults standardUserDefaults]
                                   boolForKey:@"useCustomColorForOverdueTasks"]) ?
             [[NSUserDefaults standardUserDefaults] colorForKey:@"overdueColor"] :
@@ -107,6 +111,7 @@
                       useHighlightColorsInTaskList:useHighlightColorsInTaskList
                                     completedColor:completedColor
                                      dueTodayColor:dueTodayColor
+                                      dueSoonColor:dueSoonColor
                                       overdueColor:overdueColor
                                       projectColor:projectColor
                                       contextColor:contextColor

--- a/TodoTxtMac/TTMTask.h
+++ b/TodoTxtMac/TTMTask.h
@@ -59,6 +59,7 @@
 typedef enum : NSUInteger {
     Overdue,
     DueToday,
+    DueSoon,
     NotDue,
     NoDueDate
 } TTMDueState;
@@ -174,6 +175,7 @@ typedef enum : NSUInteger {
       useHighlightColorsInTaskList:(BOOL)useHighlightColorsInTaskList
                     completedColor:(NSColor*)completedColor
                      dueTodayColor:(NSColor*)dueTodayColor
+                      dueSoonColor:(NSColor*)dueSoonColor
                       overdueColor:(NSColor*)overdueColor
                       projectColor:(NSColor*)projectColor
                       contextColor:(NSColor*)contextColor

--- a/TodoTxtMac/TTMTask.m
+++ b/TodoTxtMac/TTMTask.m
@@ -272,6 +272,7 @@ static NSString * const HiddenPattern = @"(?<=^|[ ])(h:1)(?=[ ]|$)";
       useHighlightColorsInTaskList:(BOOL)useHighlightColorsInTaskList
                     completedColor:(NSColor*)completedColor
                      dueTodayColor:(NSColor*)dueTodayColor
+                     dueSoonColor:(NSColor*)dueSoonColor
                       overdueColor:(NSColor*)overdueColor
                       projectColor:(NSColor*)projectColor
                       contextColor:(NSColor*)contextColor
@@ -314,6 +315,11 @@ static NSString * const HiddenPattern = @"(?<=^|[ ])(h:1)(?=[ ]|$)";
     // Color due texts.
     if (self.dueState == DueToday) {
         [as applyColorToFullStringRange:dueTodayColor];
+    }
+    
+    // Color due soon texts.
+    if (self.dueState == DueSoon) {
+        [as applyColorToFullStringRange:dueSoonColor];
     }
     
     // Color overdue texts.
@@ -441,10 +447,14 @@ static NSString * const HiddenPattern = @"(?<=^|[ ])(h:1)(?=[ ]|$)";
                                                           fromDate:todaysDate
                                                             toDate:self.dueDate
                                                            options:0] day];
+    NSInteger dueSoonDays = [[NSUserDefaults standardUserDefaults] integerForKey:@"dueSoonDays"];
+    
     if (interval < 0) {
         return Overdue;
-    } else if (interval > 0) {
+    } else if (interval > dueSoonDays) {
         return NotDue;
+    } else if (interval > 0) {
+        return DueSoon;
     } else {
         return DueToday;
     }

--- a/TodoTxtMac/TTMTask.m
+++ b/TodoTxtMac/TTMTask.m
@@ -272,7 +272,7 @@ static NSString * const HiddenPattern = @"(?<=^|[ ])(h:1)(?=[ ]|$)";
       useHighlightColorsInTaskList:(BOOL)useHighlightColorsInTaskList
                     completedColor:(NSColor*)completedColor
                      dueTodayColor:(NSColor*)dueTodayColor
-                     dueSoonColor:(NSColor*)dueSoonColor
+                      dueSoonColor:(NSColor*)dueSoonColor
                       overdueColor:(NSColor*)overdueColor
                       projectColor:(NSColor*)projectColor
                       contextColor:(NSColor*)contextColor


### PR DESCRIPTION
Coming from OmniFocus, the biggest thing I've found missing in TodoTxtMac so far is the ability to filter by tasks that are due soon (a few days from now). This pull request adds a "due soon" feature and includes a preference setting to define how many days in the future count as "soon".

Tasks that are due soon are highlighted in orange. I didn't add the ability to change this color in preferences yet, but I'd be happy to do so if you're interested in merging this request.

(I also found a mix of tabs and spaces in TTMPredicateEditorDueRowTemplate.m, so I went ahead and converted all tabs to four spaces based on the code conventions in README.md.)