### PR TITLE
Display correctly in Mojave dark mode

### DIFF
--- a/TodoTxtMac/TTMDocument.m
+++ b/TodoTxtMac/TTMDocument.m
@@ -172,7 +172,7 @@ static NSString * const RelativeDueDatePattern = @"(?<=due:)\\S*";
     self.customFieldEditor.projectsArray = self.tasklistMetadata.projectsArray;
     self.customFieldEditor.contextsArray = self.tasklistMetadata.contextsArray;
     self.customFieldEditor.drawsBackground = YES;
-    self.customFieldEditor.backgroundColor = [NSColor whiteColor];
+    self.customFieldEditor.backgroundColor = NSColor.textBackgroundColor;
     return self.customFieldEditor;
 }
 


### PR DESCRIPTION
TodoTxtMac generally works correctly in dark mode except that the todo entry field is drawn with a white background (and the "default" text color). This works fine in light mode, but it means that text is invisible when you type it.

I changed the custom text field to use `NSColor.textBackgroundColor` as recommended by Apple. See:

- https://developer.apple.com/documentation/appkit/supporting_dark_mode_in_your_interface
- https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/dark-mode/